### PR TITLE
LOVE-1145

### DIFF
--- a/xl-up/__test__/test-cases/custom-docker-registry/local-xld-xlr.yaml
+++ b/xl-up/__test__/test-cases/custom-docker-registry/local-xld-xlr.yaml
@@ -22,7 +22,7 @@ XlrReportDbPass: xl-release-report
 XlKeyStore: ../xl-up/__test__/files/test-file
 XlKeyStorePass: test123
 OsType: linux
-PostgresqlWorkHostpath: /psql
+PostgresqlWorkHostpathPlain: /psql
 K8sAuthentication: FilePath
 UseCustomRegistry: true
 RegistryURL: docker.io/xebialabs

--- a/xl-up/__test__/test-cases/custom-docker-registry/local-xld.yaml
+++ b/xl-up/__test__/test-cases/custom-docker-registry/local-xld.yaml
@@ -13,7 +13,7 @@ XldDbPass: xl-deploy
 XlKeyStore: ../xl-up/__test__/files/test-file
 XlKeyStorePass: test123
 OsType: linux
-PostgresqlWorkHostpath: /psql
+PostgresqlWorkHostpathPlain: /psql
 K8sAuthentication: FilePath
 UseCustomRegistry: true
 RegistryURL: docker.io/xebialabs

--- a/xl-up/__test__/test-cases/custom-docker-registry/local-xlr.yaml
+++ b/xl-up/__test__/test-cases/custom-docker-registry/local-xlr.yaml
@@ -16,7 +16,7 @@ XlrReportDbPass: xl-release-report
 XlKeyStore: ../xl-up/__test__/files/test-file
 XlKeyStorePass: test123
 OsType: linux
-PostgresqlWorkHostpath: /psql
+PostgresqlWorkHostpathPlain: /psql
 K8sAuthentication: FilePath
 UseCustomRegistry: true
 RegistryURL: docker.io/xebialabs

--- a/xl-up/__test__/test-cases/provisioned-db/local-xld-xlr.yaml
+++ b/xl-up/__test__/test-cases/provisioned-db/local-xld-xlr.yaml
@@ -23,5 +23,5 @@ XlKeyStore: ../xl-up/__test__/files/test-file
 XlKeyStorePass: test123
 XlVersion: 8.6.1
 OsType: linux
-PostgresqlWorkHostpath: /psql
+PostgresqlWorkHostpathPlain: /psql
 K8sAuthentication: FilePath

--- a/xl-up/__test__/test-cases/provisioned-db/local-xld.yaml
+++ b/xl-up/__test__/test-cases/provisioned-db/local-xld.yaml
@@ -14,5 +14,5 @@ XlKeyStore: ../xl-up/__test__/files/test-file
 XlKeyStorePass: test123
 XlVersion: 8.6.1
 OsType: linux
-PostgresqlWorkHostpath: /psql
+PostgresqlWorkHostpathPlain: /psql
 K8sAuthentication: FilePath

--- a/xl-up/__test__/test-cases/provisioned-db/local-xlr.yaml
+++ b/xl-up/__test__/test-cases/provisioned-db/local-xlr.yaml
@@ -17,5 +17,5 @@ XlKeyStore: ../xl-up/__test__/files/test-file
 XlKeyStorePass: test123
 XlVersion: 8.6.1
 OsType: linux
-PostgresqlWorkHostpath: /psql
+PostgresqlWorkHostpathPlain: /psql
 K8sAuthentication: FilePath

--- a/xl-up/blueprint.yaml
+++ b/xl-up/blueprint.yaml
@@ -669,13 +669,19 @@ spec:
       revealOnSummary: true
       description: "The password to use for accessing Grafana and Kibana"
 
-    - name: PostgresqlWorkHostpath
+    - name: PostgresqlWorkHostpathPlain
       type: Input
       prompt: "Enter the local directory path where PostgreSQL can store its data:"
       promptIf: !expr "!ExternalDatabase && K8sSetup == 'LocalK8S'"
-      saveInXlvals: true
+      saveInXlvals: false
       ignoreIfSkipped: true
       description: "Local path to a folder in your machine that will be used as a Kubernetes volume where Postgresql will persist the its data. Make sure the folder already exist and it is empty every time you run xl up command for initial deployment"
+
+    - name: PostgresqlWorkHostpath
+      type: Input
+      value: !expr "!ExternalDatabase && K8sSetup == 'LocalK8S' ? normalizePath(PostgresqlWorkHostpathPlain) : ''"
+      saveInXlvals: true
+      ignoreIfSkipped: true
 
     - name: PostgresMaxConn
       type: Input

--- a/xl-up/blueprint.yaml
+++ b/xl-up/blueprint.yaml
@@ -472,13 +472,19 @@ spec:
       ignoreIfSkipped: true
       description: "The share path on the NFS instance that which will be used for creating Kubernetes volumes for the shared folders of XL Deploy (work and export directories) or XL Release (export folder). For example: /xebialabs-share , make sure you type in the forward slash"
 
-    - name: XldWorkHostpath
+    - name: XldWorkHostpathPlain
       type: Input
       prompt: "Enter the local directory path that XL Deploy can use as a work directory:"
       promptIf: !expr "K8sSetup == 'LocalK8S' && InstallXLD && OsType != 'linux' "
       saveInXlvals: true
       ignoreIfSkipped: true
       description: "Local path to a folder in your machine that will be used as a Kubernetes volume where XL Deploy will persist the data from the work directory. Make sure the folder already exist and it is empty every time you run xl up command for initial deployment"
+
+    - name: XldWorkHostpath
+      type: Input
+      value: !expr "K8sSetup == 'LocalK8S' && InstallXLD && OsType != 'linux' ? normalizePath(XldWorkHostpathPlain) : ''"
+      saveInXlvals: true
+      ignoreIfSkipped: true
 
     - name: XlrAdminPass
       type: SecretInput
@@ -673,7 +679,7 @@ spec:
       type: Input
       prompt: "Enter the local directory path where PostgreSQL can store its data:"
       promptIf: !expr "!ExternalDatabase && K8sSetup == 'LocalK8S'"
-      saveInXlvals: false
+      saveInXlvals: true
       ignoreIfSkipped: true
       description: "Local path to a folder in your machine that will be used as a Kubernetes volume where Postgresql will persist the its data. Make sure the folder already exist and it is empty every time you run xl up command for initial deployment"
 


### PR DESCRIPTION
Add new parameter so we can support path normalization for postgres host paths on windows - need to merge in LOVE-1145 on CLI before this one

## Definition of Done

**General**
 - [x] Branch is up-to-date with beta
 - [x] Blueprint can be tested by Jenkins
 - [ ] Code is reviewed and tested by someone else in the team

**Testing**
- [x] Works on Linux, Windows and Mac
- [x] Works on all supported K8s flavors (Docker Desktop for mac/Windows, AWS EKS, Plain multinode K8s)
- [x] Functionality is manually tested where not possible to automate
- [x] Automated unit tests added and are green
- [x] Automated integration tests added where needed and are green