### PR TITLE
LOVE-1428 Up Blueprint testing framework support kubernetes annotations/labels

### DIFF
--- a/integration-tests/test-cases/custom-docker-registry/test-aks-xld-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-aks-xld-mon.yaml
@@ -12,9 +12,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
-      has_elements:
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
         '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'

--- a/integration-tests/test-cases/custom-docker-registry/test-aks-xld-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-aks-xld-mon.yaml
@@ -1,0 +1,102 @@
+extends: ../azure-base.yaml
+xl_mode: up
+expect:
+  assertion:
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
+    - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
+      has_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
+      excludes_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
+        '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/azure-load-balancer-internal': 'true'
+    secrets:
+      DockerPass: docker-pass
+      MonitoringUserPass: mon-pass
+      XlKeyStorePass: test123
+      XldAdminPass: password
+      XldDbPass: xl-deploy
+    values:
+      DockerUser: docker-user
+      InstallXLD: true
+      InstallXLR: false
+      MonitoringInstall: true
+      MonitoringUser: mon-user
+      RegistryURL: docker.io/xebialabs
+      UseCustomRegistry: true
+      XldDbName: xl-deploy
+      XldDbUser: xl-deploy
+      XldVersion: xl-deploy:8.5.3
+      XldTag: 8.5.3
+  to_exist:
+  - xebialabs/xl-deploy.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
+  - xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+  - xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-worker.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/xl-pvc/pvc-xld-export.yaml
+
+  - xebialabs/kubernetes/efk-stack/elasticsearch/rbac.yaml
+  - xebialabs/kubernetes/efk-stack/elasticsearch/deployment.yaml
+  - xebialabs/kubernetes/efk-stack/fluentd/configmap.yaml
+  - xebialabs/kubernetes/efk-stack/fluentd/daemonset.yaml
+  - xebialabs/kubernetes/efk-stack/fluentd/rbac.yaml
+  - xebialabs/kubernetes/efk-stack/kibana/deployment.yaml
+  - xebialabs/kubernetes/efk-stack/kibana/ingress.yaml
+  - xebialabs/kubernetes/efk-stack/kibana/dashboard-job.yaml
+  - xebialabs/kubernetes/efk-stack/es-curator/cronjob.yaml
+  - xebialabs/kubernetes/efk-stack/es-curator/configmap.yaml
+  - xebialabs/kubernetes/pg-stack/prometheus/rbac.yaml
+  - xebialabs/kubernetes/pg-stack/prometheus/configmap.yaml
+  - xebialabs/kubernetes/pg-stack/prometheus/deployment.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/configmap.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/secret.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/deployment.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/importer-job.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/ingress.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/pvc.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-cluster-role.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-cluster-role-binding.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-deployment.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-role.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-role-binding.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-service.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-service-account.yaml
+  to_not_exist:
+  - xebialabs/xl-release.yaml
+  - xebialabs/kubernetes/xl-release/external-db/active-active/xlr-deployment-active.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/xl-pvc/pvc-xlr-reports.yaml
+  - xebialabs/kubernetes/xl-deploy/local-db/xld-deployment-single-node.yaml
+  - xebialabs/kubernetes/xl-release/local-db/xlr-deployment-single-node.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/nfs-client-provisioner/rbac.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/nfs-client-provisioner/deployment.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/nfs-client-provisioner/storageclass.yaml
+with_answers:
+  DockerPass: docker-pass
+  DockerUser: docker-user
+  ExternalDatabase: false
+  InstallXLD: true
+  InstallXLR: false
+  MonitoringInstall: true
+  MonitoringUser: mon-user
+  MonitoringUserPass: mon-pass
+  RegistryURL: docker.io/xebialabs
+  UseCustomRegistry: true
+  XlKeyStore: ../integration-tests/files/test-file
+  XlKeyStorePass: test123
+  XldAdminPass: password
+  XldDbName: xl-deploy
+  XldDbPass: xl-deploy
+  XldDbUser: xl-deploy
+  XldLic: ../integration-tests/files/test-file
+  XldVersion: xl-deploy:8.5.3

--- a/integration-tests/test-cases/custom-docker-registry/test-aks-xld-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-aks-xld-mon.yaml
@@ -14,6 +14,9 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
           option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
+      has_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
         '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'

--- a/integration-tests/test-cases/custom-docker-registry/test-aks-xld-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-aks-xld-mon.yaml
@@ -14,9 +14,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
           option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
-      has_elements:
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
         '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'

--- a/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr-int-lb.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr-int-lb.yaml
@@ -15,8 +15,6 @@ expect:
           option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
       has_elements:
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/azure-load-balancer-internal': 'true'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'

--- a/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr-int-lb.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr-int-lb.yaml
@@ -11,8 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
       has_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'

--- a/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr-int-lb.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr-int-lb.yaml
@@ -15,6 +15,8 @@ expect:
           option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
       has_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/azure-load-balancer-internal': 'true'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'

--- a/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr-int-lb.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr-int-lb.yaml
@@ -13,8 +13,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
       has_elements:
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/azure-load-balancer-internal': 'true'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'

--- a/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr-int-lb.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr-int-lb.yaml
@@ -1,0 +1,122 @@
+extends: ../azure-base.yaml
+xl_mode: up
+expect:
+  assertion:
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
+    - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
+      has_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/azure-load-balancer-internal': 'true'
+      excludes_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
+        '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'
+    secrets:
+      DockerPass: docker-pass
+      XlKeyStorePass: test123
+      XldAdminPass: password
+      XldDbPass: xl-deploy
+      XlrAdminPass: password
+      XlrDbPass: xl-release
+      XlrReportDbPass: xl-release-report
+    values:
+      DockerUser: docker-user
+      InstallXLD: true
+      InstallXLR: true
+      MonitoringInstall: false
+      PostgresEffectCacheSize: 2GB
+      PostgresMaxConn: 400
+      PostgresMaxWallSize: 512MB
+      PostgresSharedBuff: 612MB
+      PostgresSyncCommit: 'off'
+      RegistryURL: docker.io/xebialabs
+      UseCustomRegistry: true
+      XldDbName: xl-deploy
+      XldDbUser: xl-deploy
+      XldVersion: xl-deploy:8.5.3
+      XlrDbName: xl-release
+      XlrDbUser: xl-release
+      XlrReportDbName: xl-release-report
+      XlrReportDbUser: xl-release-report
+      XlrVersion: xl-release:8.5.3
+  to_exist:
+  - xebialabs/xl-deploy.yaml
+  - xebialabs/xl-release.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/postgresql/xl-postgresql.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/xl-pvc/pvc-xld-export.yaml
+
+  - xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+  - xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-worker.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
+  - xebialabs/kubernetes/xl-release/external-db/active-active/xlr-deployment-active.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/xl-pvc/pvc-xlr-reports.yaml
+  to_not_exist:
+  - xebialabs/kubernetes/xl-deploy/local-db/xld-deployment-single-node.yaml
+  - xebialabs/kubernetes/xl-release/local-db/xlr-deployment-single-node.yaml
+  - xebialabs/kubernetes/efk-stack/elasticsearch/rbac.yaml
+  - xebialabs/kubernetes/efk-stack/elasticsearch/deployment.yaml
+  - xebialabs/kubernetes/efk-stack/fluentd/configmap.yaml
+  - xebialabs/kubernetes/efk-stack/fluentd/daemonset.yaml
+  - xebialabs/kubernetes/efk-stack/fluentd/rbac.yaml
+  - xebialabs/kubernetes/efk-stack/kibana/deployment.yaml
+  - xebialabs/kubernetes/efk-stack/kibana/ingress.yaml
+  - xebialabs/kubernetes/efk-stack/kibana/dashboard-job.yaml
+  - xebialabs/kubernetes/efk-stack/es-curator/cronjob.yaml
+  - xebialabs/kubernetes/efk-stack/es-curator/configmap.yaml
+  - xebialabs/kubernetes/pg-stack/prometheus/rbac.yaml
+  - xebialabs/kubernetes/pg-stack/prometheus/configmap.yaml
+  - xebialabs/kubernetes/pg-stack/prometheus/deployment.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/configmap.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/secret.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/deployment.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/importer-job.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/ingress.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/pvc.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-cluster-role.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-cluster-role-binding.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-deployment.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-role.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-role-binding.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-service.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-service-account.yaml
+with_answers:
+  DockerPass: docker-pass
+  DockerUser: docker-user
+  InstallXLD: true
+  InstallXLR: true
+  MonitoringInstall: false
+  PostgresEffectCacheSize: 2GB
+  PostgresMaxConn: 400
+  PostgresMaxWallSize: 512MB
+  PostgresSharedBuff: 612MB
+  PostgresSyncCommit: 'off'
+  RegistryURL: docker.io/xebialabs
+  UseCustomRegistry: true
+  XlKeyStore: ../integration-tests/files/test-file
+  XlKeyStorePass: test123
+  XldAdminPass: password
+  XldDbName: xl-deploy
+  XldDbPass: xl-deploy
+  XldDbUser: xl-deploy
+  XldLic: ../integration-tests/files/test-file
+  XldVersion: xl-deploy:8.5.3
+  XlrAdminPass: password
+  XlrDbName: xl-release
+  XlrDbPass: xl-release
+  XlrDbUser: xl-release
+  XlrLic: ../integration-tests/files/test-file
+  XlrReportDbName: xl-release-report
+  XlrReportDbPass: xl-release-report
+  XlrReportDbUser: xl-release-report
+  XlrVersion: xl-release:8.5.3
+  UseInternalLoadBalancer: true

--- a/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr-mon.yaml
@@ -12,9 +12,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
-      has_elements:
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
         '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'

--- a/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr-mon.yaml
@@ -11,8 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
       has_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'

--- a/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr-mon.yaml
@@ -14,6 +14,9 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
           option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
+      has_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
         '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'

--- a/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr-mon.yaml
@@ -1,0 +1,125 @@
+extends: ../azure-base.yaml
+xl_mode: up
+expect:
+  assertion:
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
+    - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
+      has_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
+      excludes_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
+        '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/azure-load-balancer-internal': 'true'
+    secrets:
+      DockerPass: docker-pass
+      MonitoringUserPass: mon-pass
+      XlKeyStorePass: test123
+      XldAdminPass: password
+      XldDbPass: xl-deploy
+      XlrAdminPass: password
+      XlrDbPass: xl-release
+      XlrReportDbPass: xl-release-report
+    values:
+      DockerUser: docker-user
+      InstallXLD: true
+      InstallXLR: true
+      MonitoringInstall: true
+      MonitoringUser: mon-user
+      PostgresEffectCacheSize: 2GB
+      PostgresMaxConn: 400
+      PostgresMaxWallSize: 512MB
+      PostgresSharedBuff: 612MB
+      PostgresSyncCommit: 'off'
+      RegistryURL: docker.io/xebialabs
+      UseCustomRegistry: true
+      XldDbName: xl-deploy
+      XldDbUser: xl-deploy
+      XldVersion: xl-deploy:8.5.3
+      XlrDbName: xl-release
+      XlrDbUser: xl-release
+      XlrReportDbName: xl-release-report
+      XlrReportDbUser: xl-release-report
+      XlrVersion: xl-release:8.5.3
+  to_exist:
+  - xebialabs/xl-deploy.yaml
+  - xebialabs/xl-release.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/postgresql/xl-postgresql.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/xl-pvc/pvc-xld-export.yaml
+
+  - xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+  - xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-worker.yaml
+  - xebialabs/kubernetes/xl-release/external-db/active-active/xlr-deployment-active.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/xl-pvc/pvc-xlr-reports.yaml
+  - xebialabs/kubernetes/efk-stack/elasticsearch/rbac.yaml
+  - xebialabs/kubernetes/efk-stack/elasticsearch/deployment.yaml
+  - xebialabs/kubernetes/efk-stack/fluentd/configmap.yaml
+  - xebialabs/kubernetes/efk-stack/fluentd/daemonset.yaml
+  - xebialabs/kubernetes/efk-stack/fluentd/rbac.yaml
+  - xebialabs/kubernetes/efk-stack/kibana/deployment.yaml
+  - xebialabs/kubernetes/efk-stack/kibana/ingress.yaml
+  - xebialabs/kubernetes/efk-stack/kibana/dashboard-job.yaml
+  - xebialabs/kubernetes/efk-stack/es-curator/cronjob.yaml
+  - xebialabs/kubernetes/efk-stack/es-curator/configmap.yaml
+  - xebialabs/kubernetes/pg-stack/prometheus/rbac.yaml
+  - xebialabs/kubernetes/pg-stack/prometheus/configmap.yaml
+  - xebialabs/kubernetes/pg-stack/prometheus/deployment.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/configmap.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/secret.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/deployment.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/importer-job.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/ingress.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/pvc.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-cluster-role.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-cluster-role-binding.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-deployment.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-role.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-role-binding.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-service.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-service-account.yaml
+  to_not_exist:
+  - xebialabs/kubernetes/xl-deploy/local-db/xld-deployment-single-node.yaml
+  - xebialabs/kubernetes/xl-release/local-db/xlr-deployment-single-node.yaml
+with_answers:
+  DockerPass: docker-pass
+  DockerUser: docker-user
+  InstallXLD: true
+  InstallXLR: true
+  MonitoringInstall: true
+  MonitoringUser: mon-user
+  MonitoringUserPass: mon-pass
+  PostgresEffectCacheSize: 2GB
+  PostgresMaxConn: 400
+  PostgresMaxWallSize: 512MB
+  PostgresSharedBuff: 612MB
+  PostgresSyncCommit: 'off'
+  RegistryURL: docker.io/xebialabs
+  UseCustomRegistry: true
+  XlKeyStore: ../integration-tests/files/test-file
+  XlKeyStorePass: test123
+  XldAdminPass: password
+  XldDbName: xl-deploy
+  XldDbPass: xl-deploy
+  XldDbUser: xl-deploy
+  XldLic: ../integration-tests/files/test-file
+  XldVersion: xl-deploy:8.5.3
+  XlrAdminPass: password
+  XlrDbName: xl-release
+  XlrDbPass: xl-release
+  XlrDbUser: xl-release
+  XlrLic: ../integration-tests/files/test-file
+  XlrReportDbName: xl-release-report
+  XlrReportDbPass: xl-release-report
+  XlrReportDbUser: xl-release-report
+  XlrVersion: xl-release:8.5.3

--- a/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr-mon.yaml
@@ -14,9 +14,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
           option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
-      has_elements:
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
         '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'

--- a/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr.yaml
@@ -12,9 +12,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
-      has_elements:
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
         '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'

--- a/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr.yaml
@@ -11,8 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
       has_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'

--- a/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr.yaml
@@ -14,6 +14,9 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
           option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
+      has_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
         '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'

--- a/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr.yaml
@@ -1,0 +1,121 @@
+extends: ../azure-base.yaml
+xl_mode: up
+expect:
+  assertion:
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
+    - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
+      has_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
+      excludes_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
+        '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/azure-load-balancer-internal': 'true'
+    secrets:
+      DockerPass: docker-pass
+      XlKeyStorePass: test123
+      XldAdminPass: password
+      XldDbPass: xl-deploy
+      XlrAdminPass: password
+      XlrDbPass: xl-release
+      XlrReportDbPass: xl-release-report
+    values:
+      DockerUser: docker-user
+      InstallXLD: true
+      InstallXLR: true
+      MonitoringInstall: false
+      PostgresEffectCacheSize: 2GB
+      PostgresMaxConn: 400
+      PostgresMaxWallSize: 512MB
+      PostgresSharedBuff: 612MB
+      PostgresSyncCommit: 'off'
+      RegistryURL: docker.io/xebialabs
+      UseCustomRegistry: true
+      XldDbName: xl-deploy
+      XldDbUser: xl-deploy
+      XldVersion: xl-deploy:8.5.3
+      XlrDbName: xl-release
+      XlrDbUser: xl-release
+      XlrReportDbName: xl-release-report
+      XlrReportDbUser: xl-release-report
+      XlrVersion: xl-release:8.5.3
+  to_exist:
+  - xebialabs/xl-deploy.yaml
+  - xebialabs/xl-release.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/postgresql/xl-postgresql.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/xl-pvc/pvc-xld-export.yaml
+
+  - xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+  - xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-worker.yaml
+  - xebialabs/kubernetes/xl-release/external-db/active-active/xlr-deployment-active.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/xl-pvc/pvc-xlr-reports.yaml
+  to_not_exist:
+  - xebialabs/kubernetes/xl-deploy/local-db/xld-deployment-single-node.yaml
+  - xebialabs/kubernetes/xl-release/local-db/xlr-deployment-single-node.yaml
+  - xebialabs/kubernetes/efk-stack/elasticsearch/rbac.yaml
+  - xebialabs/kubernetes/efk-stack/elasticsearch/deployment.yaml
+  - xebialabs/kubernetes/efk-stack/fluentd/configmap.yaml
+  - xebialabs/kubernetes/efk-stack/fluentd/daemonset.yaml
+  - xebialabs/kubernetes/efk-stack/fluentd/rbac.yaml
+  - xebialabs/kubernetes/efk-stack/kibana/deployment.yaml
+  - xebialabs/kubernetes/efk-stack/kibana/ingress.yaml
+  - xebialabs/kubernetes/efk-stack/kibana/dashboard-job.yaml
+  - xebialabs/kubernetes/efk-stack/es-curator/cronjob.yaml
+  - xebialabs/kubernetes/efk-stack/es-curator/configmap.yaml
+  - xebialabs/kubernetes/pg-stack/prometheus/rbac.yaml
+  - xebialabs/kubernetes/pg-stack/prometheus/configmap.yaml
+  - xebialabs/kubernetes/pg-stack/prometheus/deployment.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/configmap.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/secret.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/deployment.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/importer-job.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/ingress.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/pvc.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-cluster-role.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-cluster-role-binding.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-deployment.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-role.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-role-binding.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-service.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-service-account.yaml
+with_answers:
+  DockerPass: docker-pass
+  DockerUser: docker-user
+  InstallXLD: true
+  InstallXLR: true
+  MonitoringInstall: false
+  PostgresEffectCacheSize: 2GB
+  PostgresMaxConn: 400
+  PostgresMaxWallSize: 512MB
+  PostgresSharedBuff: 612MB
+  PostgresSyncCommit: 'off'
+  RegistryURL: docker.io/xebialabs
+  UseCustomRegistry: true
+  XlKeyStore: ../integration-tests/files/test-file
+  XlKeyStorePass: test123
+  XldAdminPass: password
+  XldDbName: xl-deploy
+  XldDbPass: xl-deploy
+  XldDbUser: xl-deploy
+  XldLic: ../integration-tests/files/test-file
+  XldVersion: xl-deploy:8.5.3
+  XlrAdminPass: password
+  XlrDbName: xl-release
+  XlrDbPass: xl-release
+  XlrDbUser: xl-release
+  XlrLic: ../integration-tests/files/test-file
+  XlrReportDbName: xl-release-report
+  XlrReportDbPass: xl-release-report
+  XlrReportDbUser: xl-release-report
+  XlrVersion: xl-release:8.5.3

--- a/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-aks-xld-xlr.yaml
@@ -14,9 +14,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
           option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
-      has_elements:
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
         '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'

--- a/integration-tests/test-cases/custom-docker-registry/test-aks-xlr-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-aks-xlr-mon.yaml
@@ -4,9 +4,6 @@ expect:
   assertion:
     generated_files:
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
-      has_elements:
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
         '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'

--- a/integration-tests/test-cases/custom-docker-registry/test-aks-xlr-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-aks-xlr-mon.yaml
@@ -4,6 +4,9 @@ expect:
   assertion:
     generated_files:
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
+      has_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
         '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'

--- a/integration-tests/test-cases/custom-docker-registry/test-aks-xlr-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-aks-xlr-mon.yaml
@@ -1,0 +1,105 @@
+extends: ../azure-base.yaml
+xl_mode: up
+expect:
+  assertion:
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
+      has_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
+      excludes_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
+        '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/azure-load-balancer-internal': 'true'
+    secrets:
+      DockerPass: docker-pass
+      MonitoringUserPass: mon-pass
+      XlKeyStorePass: test123
+      XlrAdminPass: password
+      XlrDbPass: xl-release
+      XlrReportDbPass: xl-release-report
+    values:
+      DockerUser: docker-user
+      InstallXLD: false
+      InstallXLR: true
+      MonitoringInstall: true
+      MonitoringUser: mon-user
+      PostgresEffectCacheSize: 2GB
+      PostgresMaxConn: 400
+      PostgresMaxWallSize: 512MB
+      PostgresSharedBuff: 612MB
+      PostgresSyncCommit: 'off'
+      RegistryURL: docker.io/xebialabs
+      UseCustomRegistry: true
+      XlrDbName: xl-release
+      XlrDbUser: xl-release
+      XlrReportDbName: xl-release-report
+      XlrReportDbUser: xl-release-report
+      XlrVersion: xl-release:8.5.3
+  to_exist:
+  - xebialabs/xl-release.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/postgresql/xl-postgresql.yaml
+  - xebialabs/kubernetes/xl-release/external-db/active-active/xlr-deployment-active.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/xl-pvc/pvc-xlr-reports.yaml
+  - xebialabs/kubernetes/efk-stack/elasticsearch/rbac.yaml
+  - xebialabs/kubernetes/efk-stack/elasticsearch/deployment.yaml
+  - xebialabs/kubernetes/efk-stack/fluentd/configmap.yaml
+  - xebialabs/kubernetes/efk-stack/fluentd/daemonset.yaml
+  - xebialabs/kubernetes/efk-stack/fluentd/rbac.yaml
+  - xebialabs/kubernetes/efk-stack/kibana/deployment.yaml
+  - xebialabs/kubernetes/efk-stack/kibana/ingress.yaml
+  - xebialabs/kubernetes/efk-stack/kibana/dashboard-job.yaml
+  - xebialabs/kubernetes/efk-stack/es-curator/cronjob.yaml
+  - xebialabs/kubernetes/efk-stack/es-curator/configmap.yaml
+  - xebialabs/kubernetes/pg-stack/prometheus/rbac.yaml
+  - xebialabs/kubernetes/pg-stack/prometheus/configmap.yaml
+  - xebialabs/kubernetes/pg-stack/prometheus/deployment.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/configmap.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/secret.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/deployment.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/importer-job.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/ingress.yaml
+  - xebialabs/kubernetes/pg-stack/grafana/pvc.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-cluster-role.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-cluster-role-binding.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-deployment.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-role.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-role-binding.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-service.yaml
+  - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-service-account.yaml
+  to_not_exist:
+  - xebialabs/xl-deploy.yaml
+  - xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+  - xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-worker.yaml
+  - xebialabs/kubernetes/xl-deploy/local-db/xld-deployment-single-node.yaml
+  - xebialabs/kubernetes/xl-release/local-db/xlr-deployment-single-node.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/xl-pvc/pvc-xld-export.yaml
+
+with_answers:
+  DockerPass: docker-pass
+  DockerUser: docker-user
+  InstallXLD: false
+  InstallXLR: true
+  MonitoringInstall: true
+  MonitoringUser: mon-user
+  MonitoringUserPass: mon-pass
+  PostgresEffectCacheSize: 2GB
+  PostgresMaxConn: 400
+  PostgresMaxWallSize: 512MB
+  PostgresSharedBuff: 612MB
+  PostgresSyncCommit: 'off'
+  RegistryURL: docker.io/xebialabs
+  UseCustomRegistry: true
+  XlKeyStore: ../integration-tests/files/test-file
+  XlKeyStorePass: test123
+  XldVersion: xl-deploy:8.5.3
+  XlrAdminPass: password
+  XlrDbName: xl-release
+  XlrDbPass: xl-release
+  XlrDbUser: xl-release
+  XlrLic: ../integration-tests/files/test-file
+  XlrReportDbName: xl-release-report
+  XlrReportDbPass: xl-release-report
+  XlrReportDbUser: xl-release-report
+  XlrVersion: xl-release:8.5.3

--- a/integration-tests/test-cases/custom-docker-registry/test-eks-xld-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-eks-xld-mon.yaml
@@ -11,8 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
       has_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'

--- a/integration-tests/test-cases/custom-docker-registry/test-eks-xld-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-eks-xld-mon.yaml
@@ -2,12 +2,17 @@ extends: ../eks-base.yaml
 xl_mode: up
 expect:
   assertion:
-    #generated_files:
-    #  - file_name: xebialabs/deployments.yaml
-    #    excludes_elements:
-    #      - '[3]spec'
-    #    has_elements:
-    #      '[2]spec.package': 'Applications/XEBIALABS/XL-DEPLOY/XL-Deploy-Deployment/8.5.3'
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       DockerPass: docker-pass
       MonitoringUserPass: mon-pass

--- a/integration-tests/test-cases/custom-docker-registry/test-eks-xld-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-eks-xld-mon.yaml
@@ -13,6 +13,14 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
         '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
           option httpchk GET /deployit/ha/health HTTP/1.0
+    - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
+      has_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
+      excludes_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
+        '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/azure-load-balancer-internal': 'true'
     secrets:
       DockerPass: docker-pass
       MonitoringUserPass: mon-pass
@@ -35,6 +43,7 @@ expect:
   - xebialabs/xl-deploy.yaml
   - xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
   - xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-worker.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
   - xebialabs/kubernetes/xl-k8s-foundation/xl-pvc/pvc-xld-export.yaml
 
   - xebialabs/kubernetes/efk-stack/elasticsearch/rbac.yaml

--- a/integration-tests/test-cases/custom-docker-registry/test-eks-xld-xlr-int-lb.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-eks-xld-xlr-int-lb.yaml
@@ -11,8 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
       has_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'

--- a/integration-tests/test-cases/custom-docker-registry/test-eks-xld-xlr-int-lb.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-eks-xld-xlr-int-lb.yaml
@@ -17,13 +17,12 @@ expect:
       has_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
-      excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
+      excludes_elements:
         '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/azure-load-balancer-internal': 'true'
     secrets:
       DockerPass: docker-pass
-      MonitoringUserPass: mon-pass
       XlKeyStorePass: test123
       XldAdminPass: password
       XldDbPass: xl-deploy
@@ -34,8 +33,7 @@ expect:
       DockerUser: docker-user
       InstallXLD: true
       InstallXLR: true
-      MonitoringInstall: true
-      MonitoringUser: mon-user
+      MonitoringInstall: false
       PostgresEffectCacheSize: 2GB
       PostgresMaxConn: 400
       PostgresMaxWallSize: 512MB
@@ -62,6 +60,9 @@ expect:
   - xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-worker.yaml
   - xebialabs/kubernetes/xl-release/external-db/active-active/xlr-deployment-active.yaml
   - xebialabs/kubernetes/xl-k8s-foundation/xl-pvc/pvc-xlr-reports.yaml
+  to_not_exist:
+  - xebialabs/kubernetes/xl-deploy/local-db/xld-deployment-single-node.yaml
+  - xebialabs/kubernetes/xl-release/local-db/xlr-deployment-single-node.yaml
   - xebialabs/kubernetes/efk-stack/elasticsearch/rbac.yaml
   - xebialabs/kubernetes/efk-stack/elasticsearch/deployment.yaml
   - xebialabs/kubernetes/efk-stack/fluentd/configmap.yaml
@@ -88,17 +89,12 @@ expect:
   - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-role-binding.yaml
   - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-service.yaml
   - xebialabs/kubernetes/pg-stack/kube-state-metrics/kube-state-metrics-service-account.yaml
-  to_not_exist:
-  - xebialabs/kubernetes/xl-deploy/local-db/xld-deployment-single-node.yaml
-  - xebialabs/kubernetes/xl-release/local-db/xlr-deployment-single-node.yaml
 with_answers:
   DockerPass: docker-pass
   DockerUser: docker-user
   InstallXLD: true
   InstallXLR: true
-  MonitoringInstall: true
-  MonitoringUser: mon-user
-  MonitoringUserPass: mon-pass
+  MonitoringInstall: false
   PostgresEffectCacheSize: 2GB
   PostgresMaxConn: 400
   PostgresMaxWallSize: 512MB
@@ -123,3 +119,4 @@ with_answers:
   XlrReportDbPass: xl-release-report
   XlrReportDbUser: xl-release-report
   XlrVersion: xl-release:8.5.3
+  UseInternalLoadBalancer: true

--- a/integration-tests/test-cases/custom-docker-registry/test-eks-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-eks-xld-xlr-mon.yaml
@@ -11,8 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
       has_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'

--- a/integration-tests/test-cases/custom-docker-registry/test-eks-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-eks-xld-xlr-mon.yaml
@@ -2,7 +2,17 @@ extends: ../eks-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       DockerPass: docker-pass
       MonitoringUserPass: mon-pass

--- a/integration-tests/test-cases/custom-docker-registry/test-eks-xld-xlr.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-eks-xld-xlr.yaml
@@ -11,8 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
       has_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'

--- a/integration-tests/test-cases/custom-docker-registry/test-eks-xld-xlr.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-eks-xld-xlr.yaml
@@ -13,6 +13,14 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
         '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
           option httpchk GET /deployit/ha/health HTTP/1.0
+    - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
+      has_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
+      excludes_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
+        '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/azure-load-balancer-internal': 'true'
     secrets:
       DockerPass: docker-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/custom-docker-registry/test-eks-xld-xlr.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-eks-xld-xlr.yaml
@@ -2,7 +2,17 @@ extends: ../eks-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       DockerPass: docker-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/custom-docker-registry/test-eks-xlr-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-eks-xlr-mon.yaml
@@ -2,7 +2,15 @@ extends: ../eks-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
+      has_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
+      excludes_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
+        '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/azure-load-balancer-internal': 'true'
     secrets:
       DockerPass: docker-pass
       MonitoringUserPass: mon-pass
@@ -32,6 +40,7 @@ expect:
   - xebialabs/xl-release.yaml
   - xebialabs/kubernetes/xl-k8s-foundation/postgresql/xl-postgresql.yaml
   - xebialabs/kubernetes/xl-release/external-db/active-active/xlr-deployment-active.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
   - xebialabs/kubernetes/xl-k8s-foundation/xl-pvc/pvc-xlr-reports.yaml
   - xebialabs/kubernetes/efk-stack/elasticsearch/rbac.yaml
   - xebialabs/kubernetes/efk-stack/elasticsearch/deployment.yaml

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xld-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xld-mon.yaml
@@ -12,9 +12,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
-      has_elements:
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
         '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xld-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xld-mon.yaml
@@ -11,8 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
       has_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xld-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xld-mon.yaml
@@ -2,7 +2,17 @@ extends: ../gke-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       DockerPass: docker-pass
       MonitoringUserPass: mon-pass

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xld-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xld-mon.yaml
@@ -14,6 +14,9 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
           option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
+      has_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
         '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xld-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xld-mon.yaml
@@ -13,6 +13,14 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
         '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
           option httpchk GET /deployit/ha/health HTTP/1.0
+    - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
+      has_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
+      excludes_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
+        '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/azure-load-balancer-internal': 'true'
     secrets:
       DockerPass: docker-pass
       MonitoringUserPass: mon-pass
@@ -38,6 +46,7 @@ expect:
   to_exist:
   - xebialabs/xl-deploy.yaml
   - xebialabs/kubernetes/xl-k8s-foundation/postgresql/xl-postgresql.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
   - xebialabs/kubernetes/xl-k8s-foundation/xl-pvc/pvc-xld-export.yaml
 
   - xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xld-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xld-mon.yaml
@@ -11,11 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-    - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
-      excludes_elements:
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
-        '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/azure-load-balancer-internal': 'true'
     secrets:
       DockerPass: docker-pass
       MonitoringUserPass: mon-pass

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xld-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xld-mon.yaml
@@ -14,9 +14,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
           option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
-      has_elements:
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
         '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr-int-lb.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr-int-lb.yaml
@@ -13,8 +13,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
       has_elements:
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
         '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr-int-lb.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr-int-lb.yaml
@@ -11,8 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
       has_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr-int-lb.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr-int-lb.yaml
@@ -15,8 +15,6 @@ expect:
           option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
       has_elements:
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
         '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr-int-lb.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr-int-lb.yaml
@@ -17,9 +17,9 @@ expect:
       has_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
+        '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
-        '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/azure-load-balancer-internal': 'true'
     secrets:
       DockerPass: docker-pass
@@ -57,8 +57,8 @@ expect:
 
   - xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
   - xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-worker.yaml
-  - xebialabs/kubernetes/xl-release/external-db/active-active/xlr-deployment-active.yaml
   - xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
+  - xebialabs/kubernetes/xl-release/external-db/active-active/xlr-deployment-active.yaml
   - xebialabs/kubernetes/xl-k8s-foundation/xl-pvc/pvc-xlr-reports.yaml
   to_not_exist:
   - xebialabs/kubernetes/xl-deploy/local-db/xld-deployment-single-node.yaml
@@ -119,3 +119,4 @@ with_answers:
   XlrReportDbPass: xl-release-report
   XlrReportDbUser: xl-release-report
   XlrVersion: xl-release:8.5.3
+  UseInternalLoadBalancer: true

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr-int-lb.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr-int-lb.yaml
@@ -15,6 +15,8 @@ expect:
           option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
       has_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
         '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr-mon.yaml
@@ -12,9 +12,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
-      has_elements:
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
         '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr-mon.yaml
@@ -11,8 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
       has_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr-mon.yaml
@@ -13,6 +13,14 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
         '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
           option httpchk GET /deployit/ha/health HTTP/1.0
+    - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
+      has_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
+      excludes_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
+        '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/azure-load-balancer-internal': 'true'
     secrets:
       DockerPass: docker-pass
       MonitoringUserPass: mon-pass
@@ -47,6 +55,7 @@ expect:
   - xebialabs/xl-deploy.yaml
   - xebialabs/xl-release.yaml
   - xebialabs/kubernetes/xl-k8s-foundation/postgresql/xl-postgresql.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
   - xebialabs/kubernetes/xl-k8s-foundation/xl-pvc/pvc-xld-export.yaml
 
   - xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr-mon.yaml
@@ -2,7 +2,17 @@ extends: ../gke-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       DockerPass: docker-pass
       MonitoringUserPass: mon-pass

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr-mon.yaml
@@ -14,6 +14,9 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
           option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
+      has_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
         '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr-mon.yaml
@@ -11,11 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-    - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
-      excludes_elements:
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
-        '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/azure-load-balancer-internal': 'true'
     secrets:
       DockerPass: docker-pass
       MonitoringUserPass: mon-pass

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr-mon.yaml
@@ -14,9 +14,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
           option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
-      has_elements:
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
         '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr.yaml
@@ -12,9 +12,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
-      has_elements:
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
         '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr.yaml
@@ -11,8 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
       has_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr.yaml
@@ -11,11 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-    - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
-      excludes_elements:
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
-        '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/azure-load-balancer-internal': 'true'
     secrets:
       DockerPass: docker-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr.yaml
@@ -14,6 +14,9 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
           option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
+      has_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
         '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr.yaml
@@ -2,7 +2,17 @@ extends: ../gke-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       DockerPass: docker-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xld-xlr.yaml
@@ -14,9 +14,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
           option httpchk GET /deployit/ha/health HTTP/1.0
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
-      has_elements:
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
         '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xlr-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xlr-mon.yaml
@@ -2,12 +2,6 @@ extends: ../gke-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files:
-    - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
-      excludes_elements:
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
-        '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/azure-load-balancer-internal': 'true'
     secrets:
       DockerPass: docker-pass
       MonitoringUserPass: mon-pass

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xlr-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xlr-mon.yaml
@@ -4,9 +4,6 @@ expect:
   assertion:
     generated_files:
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
-      has_elements:
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
-        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
         '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xlr-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xlr-mon.yaml
@@ -2,7 +2,15 @@ extends: ../gke-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
+      has_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
+      excludes_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
+        '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/azure-load-balancer-internal': 'true'
     secrets:
       DockerPass: docker-pass
       MonitoringUserPass: mon-pass
@@ -32,6 +40,7 @@ expect:
   - xebialabs/xl-release.yaml
   - xebialabs/kubernetes/xl-k8s-foundation/postgresql/xl-postgresql.yaml
   - xebialabs/kubernetes/xl-release/external-db/active-active/xlr-deployment-active.yaml
+  - xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
   - xebialabs/kubernetes/xl-k8s-foundation/xl-pvc/pvc-xlr-reports.yaml
   - xebialabs/kubernetes/efk-stack/elasticsearch/rbac.yaml
   - xebialabs/kubernetes/efk-stack/elasticsearch/deployment.yaml

--- a/integration-tests/test-cases/custom-docker-registry/test-gke-xlr-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-gke-xlr-mon.yaml
@@ -4,6 +4,9 @@ expect:
   assertion:
     generated_files:
     - file_name: xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml
+      has_elements:
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol': 'tcp'
+        '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-connection-idle-timeout': '300'
       excludes_elements:
         '[0]metadata.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-internal': 'true'
         '[0]metadata.annotations.cloud\.google\.com/load-balancer-type': 'Internal'

--- a/integration-tests/test-cases/custom-docker-registry/test-on-prem-xld-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-on-prem-xld-mon.yaml
@@ -1,6 +1,16 @@
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       DockerPass: docker-pass
       MonitoringUserPass: mon-pass

--- a/integration-tests/test-cases/custom-docker-registry/test-on-prem-xld-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-on-prem-xld-mon.yaml
@@ -9,8 +9,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       DockerPass: docker-pass
       MonitoringUserPass: mon-pass

--- a/integration-tests/test-cases/custom-docker-registry/test-on-prem-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-on-prem-xld-xlr-mon.yaml
@@ -1,6 +1,16 @@
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       DockerPass: docker-pass
       MonitoringUserPass: mon-pass

--- a/integration-tests/test-cases/custom-docker-registry/test-on-prem-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-on-prem-xld-xlr-mon.yaml
@@ -9,8 +9,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       DockerPass: docker-pass
       MonitoringUserPass: mon-pass

--- a/integration-tests/test-cases/custom-docker-registry/test-on-prem-xld-xlr.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-on-prem-xld-xlr.yaml
@@ -9,8 +9,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       DockerPass: docker-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/custom-docker-registry/test-on-prem-xld-xlr.yaml
+++ b/integration-tests/test-cases/custom-docker-registry/test-on-prem-xld-xlr.yaml
@@ -1,6 +1,16 @@
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       DockerPass: docker-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/external-db/test-eks-xld-custom-counts.yaml
+++ b/integration-tests/test-cases/external-db/test-eks-xld-custom-counts.yaml
@@ -2,7 +2,17 @@ extends: ../eks-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[2]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       XlKeyStorePass: test123
       XldAdminPass: password

--- a/integration-tests/test-cases/external-db/test-eks-xld-custom-counts.yaml
+++ b/integration-tests/test-cases/external-db/test-eks-xld-custom-counts.yaml
@@ -11,8 +11,6 @@ expect:
         '[2]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[2]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       XlKeyStorePass: test123
       XldAdminPass: password

--- a/integration-tests/test-cases/external-db/test-eks-xld-mon.yaml
+++ b/integration-tests/test-cases/external-db/test-eks-xld-mon.yaml
@@ -11,8 +11,6 @@ expect:
         '[2]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[2]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/external-db/test-eks-xld-mon.yaml
+++ b/integration-tests/test-cases/external-db/test-eks-xld-mon.yaml
@@ -2,7 +2,17 @@ extends: ../eks-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[2]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/external-db/test-eks-xld-xlr-mon-rabbitmq.yaml
+++ b/integration-tests/test-cases/external-db/test-eks-xld-xlr-mon-rabbitmq.yaml
@@ -11,6 +11,16 @@ expect:
         '[3]spec.template.spec.containers[0].env[13].value': 'amqp://some.rabbitmq:5672'
         '[3]spec.template.spec.containers[0].env[14].value': 'test'
         '[3]spec.template.spec.containers[0].env[15].value': 'place'
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[2]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       RabbitMQPassword: place
@@ -104,7 +114,7 @@ expect:
   - xebialabs/kubernetes/xl-k8s-foundation/rabbitmq/ingress.yaml
   - xebialabs/kubernetes/xl-k8s-foundation/rabbitmq/rbac.yaml
   - xebialabs/kubernetes/xl-k8s-foundation/rabbitmq/xl-rabbitmq.yaml
-with_answers: 
+with_answers:
   ExternalDatabase: true
   InstallXLD: true
   InstallXLR: true

--- a/integration-tests/test-cases/external-db/test-eks-xld-xlr-mon-rabbitmq.yaml
+++ b/integration-tests/test-cases/external-db/test-eks-xld-xlr-mon-rabbitmq.yaml
@@ -19,8 +19,6 @@ expect:
         '[2]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[2]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       RabbitMQPassword: place

--- a/integration-tests/test-cases/external-db/test-eks-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/external-db/test-eks-xld-xlr-mon.yaml
@@ -11,8 +11,6 @@ expect:
         '[2]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[2]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/external-db/test-eks-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/external-db/test-eks-xld-xlr-mon.yaml
@@ -2,7 +2,17 @@ extends: ../eks-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[2]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/external-db/test-eks-xld-xlr.yaml
+++ b/integration-tests/test-cases/external-db/test-eks-xld-xlr.yaml
@@ -2,7 +2,17 @@ extends: ../eks-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[2]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       XlKeyStorePass: test123
       XldAdminPass: password

--- a/integration-tests/test-cases/external-db/test-eks-xld-xlr.yaml
+++ b/integration-tests/test-cases/external-db/test-eks-xld-xlr.yaml
@@ -11,8 +11,6 @@ expect:
         '[2]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[2]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       XlKeyStorePass: test123
       XldAdminPass: password

--- a/integration-tests/test-cases/external-db/test-gke-xld-custom-counts.yaml
+++ b/integration-tests/test-cases/external-db/test-gke-xld-custom-counts.yaml
@@ -2,7 +2,17 @@ extends: ../gke-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/external-db/test-gke-xld-custom-counts.yaml
+++ b/integration-tests/test-cases/external-db/test-gke-xld-custom-counts.yaml
@@ -11,8 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/external-db/test-gke-xld-mon.yaml
+++ b/integration-tests/test-cases/external-db/test-gke-xld-mon.yaml
@@ -11,8 +11,6 @@ expect:
         '[2]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[2]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/external-db/test-gke-xld-mon.yaml
+++ b/integration-tests/test-cases/external-db/test-gke-xld-mon.yaml
@@ -2,7 +2,17 @@ extends: ../gke-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[2]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/external-db/test-gke-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/external-db/test-gke-xld-xlr-mon.yaml
@@ -11,8 +11,6 @@ expect:
         '[2]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[2]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/external-db/test-gke-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/external-db/test-gke-xld-xlr-mon.yaml
@@ -2,7 +2,17 @@ extends: ../gke-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[2]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/external-db/test-gke-xld-xlr.yaml
+++ b/integration-tests/test-cases/external-db/test-gke-xld-xlr.yaml
@@ -2,7 +2,17 @@ extends: ../gke-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[2]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[2]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       XlKeyStorePass: test123
       XldAdminPass: password

--- a/integration-tests/test-cases/external-db/test-gke-xld-xlr.yaml
+++ b/integration-tests/test-cases/external-db/test-gke-xld-xlr.yaml
@@ -11,8 +11,6 @@ expect:
         '[2]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[2]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[2]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       XlKeyStorePass: test123
       XldAdminPass: password

--- a/integration-tests/test-cases/k8s-token-auth/test-gke-xld-mon.yaml
+++ b/integration-tests/test-cases/k8s-token-auth/test-gke-xld-mon.yaml
@@ -2,7 +2,17 @@ extends: ../gke-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/k8s-token-auth/test-gke-xld-mon.yaml
+++ b/integration-tests/test-cases/k8s-token-auth/test-gke-xld-mon.yaml
@@ -11,8 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/k8s-token-auth/test-gke-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/k8s-token-auth/test-gke-xld-xlr-mon.yaml
@@ -2,7 +2,17 @@ extends: ../gke-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/k8s-token-auth/test-gke-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/k8s-token-auth/test-gke-xld-xlr-mon.yaml
@@ -11,8 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/k8s-token-auth/test-gke-xld-xlr.yaml
+++ b/integration-tests/test-cases/k8s-token-auth/test-gke-xld-xlr.yaml
@@ -2,7 +2,17 @@ extends: ../gke-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       XlKeyStorePass: test123
       XldAdminPass: password

--- a/integration-tests/test-cases/k8s-token-auth/test-gke-xld-xlr.yaml
+++ b/integration-tests/test-cases/k8s-token-auth/test-gke-xld-xlr.yaml
@@ -11,8 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       XlKeyStorePass: test123
       XldAdminPass: password

--- a/integration-tests/test-cases/k8s-token-auth/test-on-prem-xld-mon.yaml
+++ b/integration-tests/test-cases/k8s-token-auth/test-on-prem-xld-mon.yaml
@@ -1,6 +1,16 @@
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/k8s-token-auth/test-on-prem-xld-mon.yaml
+++ b/integration-tests/test-cases/k8s-token-auth/test-on-prem-xld-mon.yaml
@@ -9,8 +9,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/k8s-token-auth/test-on-prem-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/k8s-token-auth/test-on-prem-xld-xlr-mon.yaml
@@ -1,6 +1,16 @@
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/k8s-token-auth/test-on-prem-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/k8s-token-auth/test-on-prem-xld-xlr-mon.yaml
@@ -9,8 +9,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/k8s-token-auth/test-on-prem-xld-xlr.yaml
+++ b/integration-tests/test-cases/k8s-token-auth/test-on-prem-xld-xlr.yaml
@@ -9,8 +9,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       XlKeyStorePass: test123
       XldAdminPass: password

--- a/integration-tests/test-cases/k8s-token-auth/test-on-prem-xld-xlr.yaml
+++ b/integration-tests/test-cases/k8s-token-auth/test-on-prem-xld-xlr.yaml
@@ -1,6 +1,16 @@
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       XlKeyStorePass: test123
       XldAdminPass: password

--- a/integration-tests/test-cases/provisioned-db/test-azure-xld-mon.yaml
+++ b/integration-tests/test-cases/provisioned-db/test-azure-xld-mon.yaml
@@ -2,7 +2,17 @@ extends: ../azure-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/provisioned-db/test-azure-xld-mon.yaml
+++ b/integration-tests/test-cases/provisioned-db/test-azure-xld-mon.yaml
@@ -11,8 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/provisioned-db/test-azure-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/provisioned-db/test-azure-xld-xlr-mon.yaml
@@ -2,7 +2,17 @@ extends: ../azure-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/provisioned-db/test-azure-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/provisioned-db/test-azure-xld-xlr-mon.yaml
@@ -11,8 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/provisioned-db/test-azure-xld-xlr.yaml
+++ b/integration-tests/test-cases/provisioned-db/test-azure-xld-xlr.yaml
@@ -11,8 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       XlKeyStorePass: test123
       XldAdminPass: password

--- a/integration-tests/test-cases/provisioned-db/test-azure-xld-xlr.yaml
+++ b/integration-tests/test-cases/provisioned-db/test-azure-xld-xlr.yaml
@@ -2,7 +2,17 @@ extends: ../azure-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       XlKeyStorePass: test123
       XldAdminPass: password

--- a/integration-tests/test-cases/provisioned-db/test-eks-xld-mon.yaml
+++ b/integration-tests/test-cases/provisioned-db/test-eks-xld-mon.yaml
@@ -2,7 +2,17 @@ extends: ../eks-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/provisioned-db/test-eks-xld-mon.yaml
+++ b/integration-tests/test-cases/provisioned-db/test-eks-xld-mon.yaml
@@ -11,8 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/provisioned-db/test-eks-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/provisioned-db/test-eks-xld-xlr-mon.yaml
@@ -2,7 +2,17 @@ extends: ../eks-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/provisioned-db/test-eks-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/provisioned-db/test-eks-xld-xlr-mon.yaml
@@ -11,8 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/provisioned-db/test-eks-xld-xlr.yaml
+++ b/integration-tests/test-cases/provisioned-db/test-eks-xld-xlr.yaml
@@ -2,7 +2,17 @@ extends: ../eks-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       XlKeyStorePass: test123
       XldAdminPass: password

--- a/integration-tests/test-cases/provisioned-db/test-eks-xld-xlr.yaml
+++ b/integration-tests/test-cases/provisioned-db/test-eks-xld-xlr.yaml
@@ -11,8 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       XlKeyStorePass: test123
       XldAdminPass: password

--- a/integration-tests/test-cases/provisioned-db/test-gke-xld-mon.yaml
+++ b/integration-tests/test-cases/provisioned-db/test-gke-xld-mon.yaml
@@ -2,7 +2,17 @@ extends: ../gke-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/provisioned-db/test-gke-xld-mon.yaml
+++ b/integration-tests/test-cases/provisioned-db/test-gke-xld-mon.yaml
@@ -11,8 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/provisioned-db/test-gke-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/provisioned-db/test-gke-xld-xlr-mon.yaml
@@ -2,7 +2,17 @@ extends: ../gke-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/provisioned-db/test-gke-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/provisioned-db/test-gke-xld-xlr-mon.yaml
@@ -11,8 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/provisioned-db/test-gke-xld-xlr.yaml
+++ b/integration-tests/test-cases/provisioned-db/test-gke-xld-xlr.yaml
@@ -2,7 +2,17 @@ extends: ../gke-base.yaml
 xl_mode: up
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       XlKeyStorePass: test123
       XldAdminPass: password

--- a/integration-tests/test-cases/provisioned-db/test-gke-xld-xlr.yaml
+++ b/integration-tests/test-cases/provisioned-db/test-gke-xld-xlr.yaml
@@ -11,8 +11,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       XlKeyStorePass: test123
       XldAdminPass: password

--- a/integration-tests/test-cases/provisioned-db/test-on-prem-xld-mon.yaml
+++ b/integration-tests/test-cases/provisioned-db/test-on-prem-xld-mon.yaml
@@ -1,6 +1,16 @@
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/provisioned-db/test-on-prem-xld-mon.yaml
+++ b/integration-tests/test-cases/provisioned-db/test-on-prem-xld-mon.yaml
@@ -9,8 +9,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/provisioned-db/test-on-prem-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/provisioned-db/test-on-prem-xld-xlr-mon.yaml
@@ -1,6 +1,16 @@
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/provisioned-db/test-on-prem-xld-xlr-mon.yaml
+++ b/integration-tests/test-cases/provisioned-db/test-on-prem-xld-xlr-mon.yaml
@@ -9,8 +9,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       MonitoringUserPass: mon-pass
       XlKeyStorePass: test123

--- a/integration-tests/test-cases/provisioned-db/test-on-prem-xld-xlr.yaml
+++ b/integration-tests/test-cases/provisioned-db/test-on-prem-xld-xlr.yaml
@@ -9,8 +9,6 @@ expect:
         '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
         '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
-        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
-          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       XlKeyStorePass: test123
       XldAdminPass: password

--- a/integration-tests/test-cases/provisioned-db/test-on-prem-xld-xlr.yaml
+++ b/integration-tests/test-cases/provisioned-db/test-on-prem-xld-xlr.yaml
@@ -1,6 +1,16 @@
 expect:
   assertion:
-    generated_files: []
+    generated_files:
+    - file_name: xebialabs/kubernetes/xl-deploy/external-db/active-active/xld-deployment-master.yaml
+      has_elements:
+        '[3]metadata.annotations.kubernetes\.io/ingress\.class': 'haproxy'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/rewrite-target': '/'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/ssl-redirect': 'false'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/affinity': 'cookie'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-name': 'SESSION_XLD'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/session-cookie-strategy': 'prefix'
+        '[3]metadata.annotations.ingress\.kubernetes\.io/config-backend': |
+          option httpchk GET /deployit/ha/health HTTP/1.0
     secrets:
       XlKeyStorePass: test123
       XldAdminPass: password

--- a/xl-up/xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml.tmpl
+++ b/xl-up/xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml.tmpl
@@ -8,17 +8,16 @@ metadata:
     app.kubernetes.io/part-of: haproxy-ingress
   annotations:
     {{- if eq .K8sSetup "AwsEKS"}}
-    # replace with the correct value of the generated certificate in the AWS console
-    #service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "{CERT_ARN}"
-    # the backend instances are HTTP
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "tcp"
-    # Map port 443
-    #service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "https"
-    # Ensure the ELB idle timeout is less than nginx keep-alive timeout. By default,
-    # NGINX keep-alive is set to 75s. If using WebSockets, the value will need to be
-    # increased to '3600' to avoid any potential issues.
     service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
     {{- end }}
+    {{- if eq .K8sSetup "AzureAKS"}}
+    service.beta.kubernetes.io/azure-load-balancer-tcp-idle-timeout: "300"
+    {{- end }}
+    #{{- if eq .K8sSetup "GoogleGKE"}}
+    #beta.cloud.google.com/backend-config: '{"ports": {"80":"xl-backendconfig"}}'
+    #{{- end }}
+
     # Internal load balancer tags 
     {{- if and (eq .K8sSetup "AwsEKS") (eq .UseInternalLoadBalancer true)}}
     service.beta.kubernetes.io/aws-load-balancer-internal: "true"

--- a/xl-up/xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml.tmpl
+++ b/xl-up/xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml.tmpl
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: haproxy-ingress
     app.kubernetes.io/part-of: haproxy-ingress
   annotations:
-    #{{- if eq .K8sSetup "AwsEKS"}}
+    {{- if eq .K8sSetup "AwsEKS"}}
     # replace with the correct value of the generated certificate in the AWS console
     #service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "{CERT_ARN}"
     # the backend instances are HTTP
@@ -18,7 +18,7 @@ metadata:
     # NGINX keep-alive is set to 75s. If using WebSockets, the value will need to be
     # increased to '3600' to avoid any potential issues.
     service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
-    #{{- end }}
+    {{- end }}
     # Internal load balancer tags 
     {{- if and (eq .K8sSetup "AwsEKS") (eq .UseInternalLoadBalancer true)}}
     service.beta.kubernetes.io/aws-load-balancer-internal: "true"

--- a/xl-up/xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml.tmpl
+++ b/xl-up/xebialabs/kubernetes/xl-k8s-foundation/ha-proxy-ingress-controller/service-l7.yaml.tmpl
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/name: haproxy-ingress
     app.kubernetes.io/part-of: haproxy-ingress
   annotations:
+    {{- if eq .K8sSetup "AwsEKS"}}
     # replace with the correct value of the generated certificate in the AWS console
     #service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "{CERT_ARN}"
     # the backend instances are HTTP
@@ -17,6 +18,7 @@ metadata:
     # NGINX keep-alive is set to 75s. If using WebSockets, the value will need to be
     # increased to '3600' to avoid any potential issues.
     service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
+    {{- end }}
     # Internal load balancer tags 
     {{- if and (eq .K8sSetup "AwsEKS") (eq .UseInternalLoadBalancer true)}}
     service.beta.kubernetes.io/aws-load-balancer-internal: "true"

--- a/xl-up/xebialabs/xl-k8s-foundation.yaml.tmpl
+++ b/xl-up/xebialabs/xl-k8s-foundation.yaml.tmpl
@@ -162,9 +162,9 @@ spec:
                     {{- if ne .K8sSetup "PlainK8SCluster"}}
                   K8s-StorageClass: "1.0"
                     {{- end }}
-                    {{- if ne .K8sSetup "AwsEKS"}}
+                    {{- if or (eq .K8sSetup "GoogleGKE") (eq .K8sSetup "PlainK8SCluster")}}
                   K8s-NFS-Client-Provisioner: "v3.1.0-k8s1.11"
-                    {{- else }}
+                    {{- else if eq .K8sSetup "AwsEKS" }}
                   K8S-EFS-Provisioner: "v1.0.0-k8s1.10"
                     {{- end }}
                   {{- end }}
@@ -218,9 +218,9 @@ spec:
                         {{- if ne .K8sSetup "PlainK8SCluster"}}
                   K8s-StorageClass: "1.0"
                         {{- end }}
-                        {{- if ne .K8sSetup "AwsEKS"}}
+                        {{- if or (eq .K8sSetup "GoogleGKE") (eq .K8sSetup "PlainK8SCluster")}}
                   K8s-NFS-Client-Provisioner: "v3.1.0-k8s1.11"
-                        {{- else }}
+                        {{- else if eq .K8sSetup "AwsEKS" }}
                   K8S-EFS-Provisioner: "v1.0.0-k8s1.10"
                         {{- end }}
                       {{- end }}


### PR DESCRIPTION
## Definition of Done

**General**
 - [ ] Branch is up-to-date with beta
 - [ ] Blueprint can be tested by Jenkins
 - [ ] Code is reviewed and tested by someone else in the team

**Testing**
- [ ] Works on Linux, Windows and Mac
- [ ] Works on all supported K8s flavors (Docker Desktop for mac/Windows, AWS EKS, Plain multinode K8s)
- [ ] Functionality is manually tested where not possible to automate
- [ ] Automated unit tests updated if needed and are green
- [ ] Automated integration tests added where needed and are green