### PR TITLE
D-40540 Fix xl up blueprint execution. Removed usage of version function

### DIFF
--- a/xl-up/blueprint.yaml
+++ b/xl-up/blueprint.yaml
@@ -130,7 +130,7 @@ spec:
 
     - name: XldOfficialVersion
       type: Input
-      prompt: "Enter the version of the XL Deploy:"
+      prompt: "Enter the version of XL Deploy:"
       promptIf: !expr "!UseCustomRegistry && InstallXLD"
       saveInXlvals: true
       ignoreIfSkipped: true
@@ -173,7 +173,7 @@ spec:
 
     - name: XlrOfficialVersion
       type: Input
-      prompt: "Enter the version of the XL Release:"
+      prompt: "Enter the version of XL Release:"
       promptIf: !expr "!UseCustomRegistry && InstallXLR"
       saveInXlvals: true
       ignoreIfSkipped: true

--- a/xl-up/blueprint.yaml
+++ b/xl-up/blueprint.yaml
@@ -129,11 +129,9 @@ spec:
       description: "Timeout interval of XL Deploy masters and workers deployment. The value of this parameter is the number of retries until readiness probe check passes and not the number of seconds. The interval between each try is 5 seconds"
 
     - name: XldOfficialVersion
-      type: Select
+      type: Input
       prompt: "Choose the version of the XL Deploy:"
       promptIf: !expr "!UseCustomRegistry && InstallXLD"
-      options:
-        - !expr "version('_showapplicableversions', 'xld')"
       saveInXlvals: true
       ignoreIfSkipped: true
       description: "The version of both XL Deploy you would like to install"
@@ -144,18 +142,17 @@ spec:
       ignoreIfSkipped: true
       prompt: "Enter your custom XL Deploy image and tag:"
       promptIf: !expr "UseCustomRegistry && InstallXLD"
-      validate: !expr "version('checkversion', 'xld', XldVersion)"
       overrideDefault: true
       description: "This will be the XL Deploy docker image and tag that lives in your private docker registry. For example xl-deploy:9.0.3 . When using custom xebialabs docker images from your own private docker registry make sure that the tag follows Semantic Versioning (https://semver.org/)"
 
       # This question will not be asked but used to extract the tag information which will be used as version
     - name: XldTag
       type: Input
-      value: !expr "(UseCustomRegistry && InstallXLD) ? version('getversionfromtag', XldVersion) : ''"
+      prompt: "Enter the XLD image tag:"
       saveInXlvals: true
       ignoreIfSkipped: true
       overrideDefault: true
-      description: "Enter the XLD custom image:"
+      description: "Enter the XLD custom image (same as version from tag):"
 
     - name: InstallXLR
       type: Confirm
@@ -175,11 +172,9 @@ spec:
       description: "Timeout interval of XL Release nodes deployment. The value of this parameter is the number of retries until readiness probe check passes and not the number of seconds. The interval between each try is 5 seconds "
 
     - name: XlrOfficialVersion
-      type: Select
+      type: Input
       prompt: "Choose the version of the XL Release:"
       promptIf: !expr "!UseCustomRegistry && InstallXLR"
-      options:
-        - !expr "version('_showapplicableversions', 'xlr')"
       saveInXlvals: true
       ignoreIfSkipped: true
       description: "The version of both XL Release you would like to install"
@@ -188,7 +183,6 @@ spec:
       type: Input
       prompt: "Enter your custom XL Release image and tag:"
       promptIf: !expr "UseCustomRegistry && InstallXLR"
-      validate: !expr "version('checkversion', 'xlr', XlrVersion)"
       saveInXlvals: true
       ignoreIfSkipped: true
       overrideDefault: true
@@ -197,11 +191,11 @@ spec:
       # This question will not be asked but used to extract the tag information which will be used as version
     - name: XlrTag
       type: Input
-      value: !expr "(UseCustomRegistry && InstallXLR) ? version('getversionfromtag', XlrVersion) : ''"
+      prompt: "Enter the XLR image tag:"
       saveInXlvals: true
       ignoreIfSkipped: true
       overrideDefault: true
-      description: "Enter the XLR custom image:"
+      description: "Enter the XLR custom image (same as version from tag):"
 
     - name: ExternalDatabase
       type: Confirm

--- a/xl-up/blueprint.yaml
+++ b/xl-up/blueprint.yaml
@@ -130,7 +130,7 @@ spec:
 
     - name: XldOfficialVersion
       type: Input
-      prompt: "Choose the version of the XL Deploy:"
+      prompt: "Enter the version of the XL Deploy:"
       promptIf: !expr "!UseCustomRegistry && InstallXLD"
       saveInXlvals: true
       ignoreIfSkipped: true
@@ -173,7 +173,7 @@ spec:
 
     - name: XlrOfficialVersion
       type: Input
-      prompt: "Choose the version of the XL Release:"
+      prompt: "Enter the version of the XL Release:"
       promptIf: !expr "!UseCustomRegistry && InstallXLR"
       saveInXlvals: true
       ignoreIfSkipped: true


### PR DESCRIPTION
## Definition of Done

**General**
 - [ ] Blueprint can be tested by Jenkins
 - [ ] Code is reviewed and tested by someone else in the team
 - [ ] Draft docs are created if needed

**Testing**
- [ ] Works on Linux, Windows and Mac
- [ ] Works on all supported K8s flavors (Docker Desktop for mac/Windows, AWS EKS, Plain multinode K8s)
- [ ] Functionality is manually tested where not possible to automate
- [ ] Automated unit tests updated if needed and are green
- [ ] Automated integration tests added where needed and are green